### PR TITLE
seek and skip beyond read buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,32 @@ or
         run(cin → deserializer()) |> fetch
     end
 ```
+It is possible to open a pipe chain for read or write like for process pipes.
+And the can be run:
+
+```julia
+    tl = open("xxx.tar" → tarxO())
+    readln(tl)
+    close(tl)
+
+    # or equivalently
+    open("xxx.tar" → tarxO()) do tl
+        readln(tl)
+    end
+
+    open(gzip() → "data.gz", "w") do tl
+        write(tl, data)
+    end
+
+    run(tarc(dir) → "dir.tar")
+```
 
 ## Predefined closures
 
 ``` julia
     tarc(dir) # take files in input directory and create tar to output stream
     tarx(dir) # read input stream and extract files to empty target directory
+    tarxO() # read input stream and concatenate all file contents to output stream
     gzip() # read input stream and write compressed data to output stream
     gunzip() # reverse of gzip
     transcoder(::Codec) # generalization for other kinds of TranscoderStreams

--- a/src/ChannelBuffers.jl
+++ b/src/ChannelBuffers.jl
@@ -8,7 +8,7 @@ import Base: pipe_reader, pipe_writer
 import Base: run, open, close, wait, fetch, eof, read, write, flush
 import Base: show, length, getindex
 import Base: unsafe_write, bytesavailable, readbytes!, unsafe_read, pipeline
-import Base: isopen, isreadable, iswritable, position, seek, peek, take!
+import Base: isopen, isreadable, iswritable, position, seek, skip, peek, take!
 import Base: iterate, broadcastable, lastindex, firstindex
 import Base: istaskstarted, istaskdone, istaskfailed
 import Base: |

--- a/src/channelio.jl
+++ b/src/channelio.jl
@@ -276,7 +276,7 @@ function takebuffer!(cio::ChannelIO{R})
             buffer = take!(cio.ch)
         catch ex
             buffer = UInt8[]
-            ex isa InterruptException && rethrow()
+            ex isa InvalidStateException || rethrow()
         end
     else
         buffer = UInt8[]

--- a/src/channelio.jl
+++ b/src/channelio.jl
@@ -137,16 +137,24 @@ function flush(cio::ChannelIO{W})
     _flush(cio, false)
 end
 
-function _flush(cio::ChannelIO{W}, close::Bool)
-    cio.offset == 0 && !close && return
+function _flush(cio::ChannelIO{W}, doclose::Bool)
+    cio.offset == 0 && !doclose && return
+    ch = cio.ch
     resize!(cio.buffer, cio.offset)
+    lock(ch)
     try
-        vput!(cio, cio.buffer)
+        if !isready(ch) || !doclose
+            vput!(cio, cio.buffer)
+        else
+            append!(fetch(ch), cio.buffer)
+        end
     catch
-        !close && rethrow()
+        !doclose && rethrow()
     finally
         cio.position += cio.offset
+        doclose && close(ch)
         newbuffer!(cio)
+        unlock(ch)
     end
     nothing
 end
@@ -163,6 +171,7 @@ function _destroy(cio::ChannelIO{R})
     finally
         cio.eofpending = true
         close(ch)
+        resize!(cio.buffer, cio.offset)
         unlock(ch)
     end
     nothing
@@ -174,8 +183,6 @@ function close(cio::ChannelIO)
        closefinish(cio)
     catch
         # ignore error during close
-    finally
-        close(cio.ch)
     end
     nothing
 end

--- a/src/tasks.jl
+++ b/src/tasks.jl
@@ -20,11 +20,6 @@ function istaskfailed(bt::BTask{T,<:Process}) where T
     process_exited(bt.task) && bt.task.exitcode != 0
 end
 
-function Base.kill(bc::BTask, ex::Exception=ErrorException("Task $bc was killed"))
-    schedule(bc.task, ex, error=true)
-    yield()
-end
-
 # List of tasks and io redirections - output of `run` and `open`
 """
     TaskChain
@@ -65,6 +60,11 @@ function fetch(tv::TaskChain, ix::Integer=0)
     0 < n || throw(ArgumentError("cannot fetch from empty task list"))
     0 < i <= n || throw(BoundsError(tv, i))
     @inbounds fetch(tv[i])
+end
+
+function Base.kill(bc::BTask, ex::Exception=ErrorException("Task $bc was killed"))
+    schedule(bc.task, ex, error=true)
+    yield()
 end
 
 function Base.kill(tl::TaskChain)

--- a/src/tasks.jl
+++ b/src/tasks.jl
@@ -70,12 +70,8 @@ end
 function Base.kill(tl::TaskChain)
     x = 1
     while (x = findnext(!istaskdone, tl.processes, x)) !== nothing
-        try
-            kill(tl[x])
-            break
-        catch
-            nothing
-        end
+        kill(tl[x])
+        break
     end
     nothing
 end

--- a/src/tasks.jl
+++ b/src/tasks.jl
@@ -80,19 +80,6 @@ function Base.kill(tl::TaskChain)
     nothing
 end
 
-"""
-    close(::TaskChain)
-
-First close pipe_writer (the device the pipe is reading from).
-That should flush all pending data, giving an EOF to the fist task which should exit.
-Then wait for the last task to be done.
-The pipe_reader would be closed automatically before the completion of the last task.
-"""
-function close(tv::TaskChain)
-    close(pipe_writer(tv))
-    close(pipe_reader(tv))
-end
-
 function show(io::IO, m::MIME"text/plain", tv::TaskChain)
     for t in tv.processes
         show(io, m, t)

--- a/test/channelio.jl
+++ b/test/channelio.jl
@@ -217,6 +217,14 @@ end
     @test close(p) === nothing
 end
 
+@testset "skip to future" begin
+    p = ChannelPipe(10)
+    schedule(Task(()->begin write(p, 'a':'z'); flush(p); end))
+    skip(p.out, 22)
+    close(p.in)
+    @test read(p, 2) == codeunits("wx")
+end
+
 nested(ex::TaskFailedException) = current_exceptions(ex.task)[1].exception
 
 @testset "close channel while put! pending" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,9 @@ end
 const DDIR = abspath(dirname(@__FILE__),"..", "data", "test")
 const TDIR = mktempdir(cleanup=false)
 
+dpath(x...) = joinpath(DDIR, x...)
+tpath(x...) = joinpath(TDIR, x...)
+
 println("testing tmpdir is $TDIR test data from $DDIR")
 println("JULIA_NUM_THREADS=$(Threads.nthreads())")
 

--- a/test/tasks.jl
+++ b/test/tasks.jl
@@ -229,4 +229,15 @@ end
     @test_throws TaskFailedException wait(tl)
     @test istaskdone(tl)
     @test istaskfailed(tl)
+
+    tl = run(`sleep 10` | noop(), wait=false)
+    while !istaskstarted(tl)
+        yield()
+    end
+    @test istaskstarted(tl[1])
+    @test !istaskdone(tl)
+    kill(tl)
+    wait(tl)
+    @test istaskdone(tl)
+    @test kill(tl) === nothing
 end


### PR DESCRIPTION
- Amended `seek` and `skip` functions to set read pointer forward to positions, which are not (yet) covered by current buffer contents.
- Introduced `kill` to stop tasks.