### PR TITLE
readbytes!(;all=false) - removed eofpending

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "ChannelBuffers"
 uuid = "79a69506-cdd1-4876-b8e5-7af85e53af4f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 authors = ["Klaus Crusius <klaus.crusius@web.de>"]
-version = "0.3.1"
+version = "0.4"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"

--- a/test/channelio.jl
+++ b/test/channelio.jl
@@ -241,3 +241,14 @@ nested(ex::TaskFailedException) = current_exceptions(ex.task)[1].exception
         @test nested(ex) isa InvalidStateException
     end
 end
+
+@testset "read some bytes" begin
+    cio = ChannelPipe()
+    write(cio, "hallo")
+    b = zeros(UInt8, 0)
+    @test readbytes!(cio, b, 10, all=false) == 0
+    flush(cio.in)
+    @test readbytes!(cio, b, 10, all=false) == 5
+    close(cio)
+    @test readbytes!(cio, b, 10) == 0
+end


### PR DESCRIPTION
`readbytes!(cio, b, n ;all=false)` now returns `bytesavailable(cio)` bytes and does not block.
`ChannelIO.eofpending` is not needed and has been removed. 